### PR TITLE
remove depricated vpc_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ```
 module "internal_zone" {
-  source = "git@github.com/rackspace-infrastructure-automation/aws-terraform-route53_internal_zone//?ref=v0.0.2"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-route53_internal_zone//?ref=v0.0.2"
 
   target_vpc_id = "vpc-12345678901234567"
   zone_name     = "customer.local"

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,9 @@ resource "aws_route53_zone" "internal_zone" {
   comment = "Hosted zone for ${local.environment}"
 
   # Check to see if input starts with 'vpc-'. True=use input, False=use empty string
-  vpc_id = "${replace(var.target_vpc_id, "/^vpc-/", "") != var.target_vpc_id ? var.target_vpc_id:""}"
+  vpc = {
+    vpc_id = "${replace(var.target_vpc_id, "/^vpc-/", "") != var.target_vpc_id ? var.target_vpc_id:""}"
+  }
 
   tags = "${merge(var.custom_tags, local.module_tags)}"
 }


### PR DESCRIPTION
##### Summary of change(s):
- fix example
- to remove warning `Warning: module.internal_zone.aws_route53_zone.internal_zone: "vpc_id": [DEPRECATED] use 'vpc' attribute instead`


##### Will the change trigger resource destruction or replacement? no:

##### Do examples need to be updated based on changes? no , all input remains the same