### PR TITLE
Removed depricated vpc_id property

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,34 @@
 # aws-terraform-route53_internal_zone
 
+This module creates an internal Route53 zone.
+
 ## Basic Usage
 
 ```
 module "internal_zone" {
-  source = "git@github.com/rackspace-infrastructure-automation/aws-terraform-route53_internal_zone//?ref=v0.0.2"
+ source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-route53_internal_zone//?ref=v0.0.3"
 
-  target_vpc_id = "vpc-12345678901234567"
-  zone_name     = "customer.local"
+ target_vpc_id = "vpc-12345678901234567"
+ zone_name     = "customer.local"
 }
 
 ```
+
+Full working references are available at [examples](examples)
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| custom_tags | Optional tags to be applied on top of the base tags on all resources | map | `<map>` | no |
-| environment | Application environment for which this network is being created. one of: ('Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test') | string | `Development` | no |
-| target_vpc_id | Select Virtual Private Cloud ID. ( vpc-* ) | string | - | yes |
-| zone_name | TLD for Internal Hosted Zone. ( example.com ) | string | - | yes |
+| custom\_tags | Optional tags to be applied on top of the base tags on all resources | map | `<map>` | no |
+| environment | Application environment for which this network is being created. one of: ('Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test') | string | `"Development"` | no |
+| target\_vpc\_id | Select Virtual Private Cloud ID. ( vpc-* ) | string | n/a | yes |
+| zone\_name | TLD for Internal Hosted Zone. ( example.com ) | string | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| internal_hosted_name | Hosted Zone Name |
-| internal_hosted_zone_id | Hosted Zone ID |
+| internal\_hosted\_name | Hosted Zone Name |
+| internal\_hosted\_zone\_id | Hosted Zone ID |
+

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 }
 
 module "internal_zone" {
-  source = "git@github.com/rackspace-infrastructure-automation/aws-terraform-route53_internal_zone//?ref=v0.0.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-route53_internal_zone//?ref=v0.0.3"
 
   zone_name = "example.com"
 

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,22 @@
-# Internal Hosted Zone
+/**
+ * # aws-terraform-route53_internal_zone
+ *
+ *This module creates an internal Route53 zone.
+ *
+ *## Basic Usage
+ *
+ *```
+ *module "internal_zone" {
+ *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-route53_internal_zone//?ref=v0.0.3"
+ *
+ *  target_vpc_id = "vpc-12345678901234567"
+ *  zone_name     = "customer.local"
+ *}
+ *
+ *```
+ *
+ * Full working references are available at [examples](examples)
+ */
 
 locals {
   env_list = ["Development", "Integration", "PreProduction", "Production", "QA", "Staging", "Test"]
@@ -18,7 +36,9 @@ resource "aws_route53_zone" "internal_zone" {
   comment = "Hosted zone for ${local.environment}"
 
   # Check to see if input starts with 'vpc-'. True=use input, False=use empty string
-  vpc_id = "${replace(var.target_vpc_id, "/^vpc-/", "") != var.target_vpc_id ? var.target_vpc_id:""}"
+  vpc = {
+    vpc_id = "${replace(var.target_vpc_id, "/^vpc-/", "") != var.target_vpc_id ? var.target_vpc_id:""}"
+  }
 
   tags = "${merge(var.custom_tags, local.module_tags)}"
 }


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):
Originally submitted in #9 by @rrakhmanto, migrated to a branch for CI testing.

##### Summary of change(s):

- Updates the Route53 zone to use the `vpc` map syntax and removes the deprecated `vpc_id` property.
- Corrects typos in module source line in readme and example
- Adds tfdocs header to main.tf for readme generation.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No 
##### If input variables or output variables have changed or has been added, have you updated the README?
Readme has been updated.

##### Do examples need to be updated based on changes?
No
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.