### PR TITLE
Force R53 zone names to lowercase

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@
  * ```HCL
  * module "internal_zone" {
  *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-route53_internal_zone//?ref=v0.12.0"
- * 
+ *
  *  name   = "customer.local"
  *  vpc_id = "vpc-12345678901234567"
  * }
@@ -21,11 +21,11 @@
  *
  * Several changes were required while adding terraform 0.12 compatibility.  The following changes should be
  * made when upgrading from a previous release to version 0.12.0 or higher.
- * 
+ *
  * ### Module variables
- * 
+ *
  * The following module variables were updated to better meet current Rackspace style guides:
- * 
+ *
  * - `custom_tags` -> `tags`
  * - `target_vpc_id` -> `vpc_id`
  * - `zone_name` -> `name`
@@ -49,7 +49,7 @@ locals {
 
 resource "aws_route53_zone" "internal_zone" {
   comment = "Hosted zone for ${var.environment}"
-  name    = var.name
+  name    = lower(var.name)
   tags    = merge(var.tags, local.module_tags)
 
   vpc {

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -15,6 +15,6 @@ module "internal_zone" {
   source = "../../module"
 
   environment = "Test"
-  name        = "example.com"
+  name        = "EXAMPLE.COM"
   vpc_id      = aws_vpc.testing.id
 }


### PR DESCRIPTION
##### Corresponding Issue(s):
 - [MPCSUPENG-1163](https://jira.rax.io/browse/MPCSUPENG-1163)
##### Summary of change(s):
Forces R53 zone name to lowercase.  This is performed within the terraform backend, however this change will suppress false positive changes during the plan phase.
##### Reason for Change(s):

- Eliminate false positive environment change

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
None required
##### Do examples need to be updated based on changes?
None required
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
